### PR TITLE
Feature/202109/clean elasticsearch class

### DIFF
--- a/src/main/java/elasticsearch/sample/CreateIndex.java
+++ b/src/main/java/elasticsearch/sample/CreateIndex.java
@@ -1,0 +1,31 @@
+package elasticsearch.sample;
+
+import java.io.IOException;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.CreateIndexResponse;
+import org.elasticsearch.common.settings.Settings;
+
+// Elasticsearch に新しい index を作成する class
+public class CreateIndex {
+
+    public static void main(String[] args) throws IOException {
+        // Elasticsearch に接続
+        RestHighLevelClient client = new RestHighLevelClient(
+                RestClient.builder(new HttpHost("localhost", 9200, "http")));
+
+        // Elasticsearch に新しい index を作成
+        CreateIndexRequest request = new CreateIndexRequest("sampleindex");
+        request.settings(Settings.builder()
+                .put("index.number_of_shards", 1)
+                .put("index.number_of_replicas", 2));
+        // index が作成されたか確認
+        CreateIndexResponse createIndexResponse = client.indices().create(request,
+                RequestOptions.DEFAULT);
+        System.out.println("response id: " + createIndexResponse.index());
+    }
+}

--- a/src/main/java/elasticsearch/sample/InsertMapData.java
+++ b/src/main/java/elasticsearch/sample/InsertMapData.java
@@ -1,6 +1,7 @@
 package elasticsearch.sample;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.index.IndexRequest;
@@ -9,18 +10,24 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 
-// String型のデータを Elasticsearch に送る class
-public class InsertStringData {
+// Map 型のデータを Elasticsearch に送る class
+public class InsertMapData {
 
     public static void main(String[] args) throws IOException {
         // Elasticsearch に接続
         RestHighLevelClient client = new RestHighLevelClient(
                 RestClient.builder(new HttpHost("localhost", 9200, "http")));
 
-        // String型のデータを Elasticsearch に送る
+        // Map 型のサンプルデータを作成
+        HashMap<String, Integer> map = new HashMap<String, Integer>();
+        map.put("keyOne", 10);
+        map.put("keyTwo", 30);
+        map.put("KeyThree", 20);
+
+        // Map 型のデータを Elasticsearch に送る
         IndexRequest indexRequest = new IndexRequest("sampleindex");
-        indexRequest.id("001");
-        indexRequest.source("SampleKey", "SampleValue");
+        indexRequest.id("002");
+        indexRequest.source(map);
         // 正常に処理されたか確認
         IndexResponse indexResponse = client.index(indexRequest,
                 RequestOptions.DEFAULT);

--- a/src/main/java/elasticsearch/sample/InsertPOJOMappingsData.java
+++ b/src/main/java/elasticsearch/sample/InsertPOJOMappingsData.java
@@ -1,0 +1,37 @@
+package elasticsearch.sample;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.xcontent.XContentType;
+
+// POJO を JSON 形式にして データを Elasticsearch に送る class
+public class InsertPOJOMappingsData {
+
+    public static void main(String[] args) throws IOException {
+        // Elasticsearch に接続
+        RestHighLevelClient client = new RestHighLevelClient(
+                RestClient.builder(new HttpHost("localhost", 9200, "http")));
+
+        // POJO クラスをインスタンス化
+        EmployeePojo emp = new EmployeePojo("Elon", "Musk", LocalDate.now());
+
+        // POJO を JSON 形式にして データを Elasticsearch に送る
+        IndexRequest indexRequest = new IndexRequest("sampleindex");
+        indexRequest.id("003");
+        indexRequest.source(new ObjectMapper().writeValueAsString(emp), XContentType.JSON);
+        System.out.println("JSONデータ" + new ObjectMapper().writeValueAsString(emp));
+        // 正常に処理されたか確認
+        IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
+        System.out.println("response id: " + indexResponse.getId());
+        System.out.println("response name: " + indexResponse.getResult().name());
+    }
+}

--- a/src/main/java/elasticsearch/sample/InsertStringData.java
+++ b/src/main/java/elasticsearch/sample/InsertStringData.java
@@ -1,0 +1,29 @@
+package elasticsearch.sample;
+
+import java.io.IOException;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+
+// String型のデータを Elasticsearch に送る class
+public class InsertStringData {
+
+    public static void main(String[] args) throws IOException {
+        // Elasticsearch に接続
+        RestHighLevelClient client = new RestHighLevelClient(
+                RestClient.builder(new HttpHost("localhost", 9200, "http")));
+
+        // String型のデータを Elasticsearch に送る
+        IndexRequest indexRequest = new IndexRequest("sampleindex");
+        indexRequest.id("001");
+        indexRequest.source("SampleKey", "SampleValue");
+        IndexResponse indexResponse = client.index(indexRequest,
+                RequestOptions.DEFAULT);
+        System.out.println("response id: " + indexResponse.getId());
+        System.out.println("response name: " + indexResponse.getResult().name());
+    }
+}

--- a/src/main/java/elasticsearch/sample/JavaElasticClient.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticClient.java
@@ -39,15 +39,17 @@ public class JavaElasticClient {
         // System.out.println("response id: " + indexResponse.getId());
         // System.out.println("response name: " + indexResponse.getResult().name());
 
-        // Map 型のデータを Elasticsearch に送る
+        // Map 型のサンプルデータを作成
         // HashMap<String, Integer> map = new HashMap<String, Integer>();
         // map.put("keyOne", 10);
         // map.put("keyTwo", 30);
         // map.put("KeyThree", 20);
 
+        // Map 型のデータを Elasticsearch に送る
         // IndexRequest indexRequest = new IndexRequest("sampleindex");
         // indexRequest.id("002");
         // indexRequest.source(map);
+        // 正常に処理されたか確認
         // IndexResponse indexResponse = client.index(indexRequest,
         // RequestOptions.DEFAULT);
         // System.out.println("response id: " + indexResponse.getId());

--- a/src/main/java/elasticsearch/sample/JavaElasticClient.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticClient.java
@@ -55,13 +55,15 @@ public class JavaElasticClient {
         // System.out.println("response id: " + indexResponse.getId());
         // System.out.println("response name: " + indexResponse.getResult().name());
 
-        // JSON 形式のデータを Elasticsearch に送る
+        // POJO クラスをインスタンス化
         EmployeePojo emp = new EmployeePojo("Elon", "Musk", LocalDate.now());
 
+        // POJO を JSON 形式にして データを Elasticsearch に送る
         IndexRequest indexRequest = new IndexRequest("sampleindex");
         indexRequest.id("003");
         indexRequest.source(new ObjectMapper().writeValueAsString(emp), XContentType.JSON);
-        System.out.println(new ObjectMapper().writeValueAsString(emp));
+        System.out.println("JSONデータ" + new ObjectMapper().writeValueAsString(emp));
+        // 正常に処理されたか確認
         IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());


### PR DESCRIPTION
### `JavaElasticCilent.java` の処理を分離してわかりやすくした

- Elasticsearch に新しい index を作成する class を作成
- String型のデータを Elasticsearch に送る class を作成
- Map 型のデータを Elasticsearch に送る class を作成
- POJO を JSON 形式にして データを Elasticsearch に送る class を作成
- 説明を追記