### PR TITLE
Feature/202109/elasticsearch update data

### DIFF
--- a/src/main/java/elasticsearch/sample/CreateIndex.java
+++ b/src/main/java/elasticsearch/sample/CreateIndex.java
@@ -23,9 +23,9 @@ public class CreateIndex {
         request.settings(Settings.builder()
                 .put("index.number_of_shards", 1)
                 .put("index.number_of_replicas", 2));
-        // index が作成されたか確認
         CreateIndexResponse createIndexResponse = client.indices().create(request,
                 RequestOptions.DEFAULT);
+        // index が作成されたか確認
         System.out.println("response id: " + createIndexResponse.index());
     }
 }

--- a/src/main/java/elasticsearch/sample/InsertMapData.java
+++ b/src/main/java/elasticsearch/sample/InsertMapData.java
@@ -28,9 +28,9 @@ public class InsertMapData {
         IndexRequest indexRequest = new IndexRequest("sampleindex");
         indexRequest.id("002");
         indexRequest.source(map);
-        // 正常に処理されたか確認
         IndexResponse indexResponse = client.index(indexRequest,
                 RequestOptions.DEFAULT);
+        // 正常に処理されたか確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());
     }

--- a/src/main/java/elasticsearch/sample/InsertPOJOMappingsData.java
+++ b/src/main/java/elasticsearch/sample/InsertPOJOMappingsData.java
@@ -29,8 +29,8 @@ public class InsertPOJOMappingsData {
         indexRequest.id("003");
         indexRequest.source(new ObjectMapper().writeValueAsString(emp), XContentType.JSON);
         System.out.println("JSONデータ" + new ObjectMapper().writeValueAsString(emp));
-        // 正常に処理されたか確認
         IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
+        // 正常に処理されたか確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());
     }

--- a/src/main/java/elasticsearch/sample/InsertStringData.java
+++ b/src/main/java/elasticsearch/sample/InsertStringData.java
@@ -21,9 +21,9 @@ public class InsertStringData {
         IndexRequest indexRequest = new IndexRequest("sampleindex");
         indexRequest.id("001");
         indexRequest.source("SampleKey", "SampleValue");
-        // 正常に処理されたか確認
         IndexResponse indexResponse = client.index(indexRequest,
                 RequestOptions.DEFAULT);
+        // 正常に処理されたか確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());
     }

--- a/src/main/java/elasticsearch/sample/JavaElasticClient.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticClient.java
@@ -25,9 +25,9 @@ public class JavaElasticClient {
         // request.settings(Settings.builder()
         // .put("index.number_of_shards", 1)
         // .put("index.number_of_replicas", 2));
-        // // index が作成されたか確認
         // CreateIndexResponse createIndexResponse = client.indices().create(request,
         // RequestOptions.DEFAULT);
+        // // index が作成されたか確認
         // System.out.println("response id: " + createIndexResponse.index());
 
         // String型のデータを Elasticsearch に送る
@@ -36,6 +36,7 @@ public class JavaElasticClient {
         // indexRequest.source("SampleKey", "SampleValue");
         // IndexResponse indexResponse = client.index(indexRequest,
         // RequestOptions.DEFAULT);
+        // // 正常に処理されたか確認
         // System.out.println("response id: " + indexResponse.getId());
         // System.out.println("response name: " + indexResponse.getResult().name());
 
@@ -49,9 +50,9 @@ public class JavaElasticClient {
         // IndexRequest indexRequest = new IndexRequest("sampleindex");
         // indexRequest.id("002");
         // indexRequest.source(map);
-        // 正常に処理されたか確認
         // IndexResponse indexResponse = client.index(indexRequest,
         // RequestOptions.DEFAULT);
+        // // 正常に処理されたか確認
         // System.out.println("response id: " + indexResponse.getId());
         // System.out.println("response name: " + indexResponse.getResult().name());
 
@@ -63,8 +64,8 @@ public class JavaElasticClient {
         indexRequest.id("003");
         indexRequest.source(new ObjectMapper().writeValueAsString(emp), XContentType.JSON);
         System.out.println("JSONデータ" + new ObjectMapper().writeValueAsString(emp));
-        // 正常に処理されたか確認
         IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
+        // 正常に処理されたか確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());
     }

--- a/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
@@ -1,0 +1,26 @@
+package elasticsearch.sample;
+
+import java.io.IOException;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+
+public class JavaElasticUpdateDelete {
+
+    public static void main(String[] args) throws IOException {
+        // Elasticsearch に接続
+        RestHighLevelClient client = new RestHighLevelClient(
+                RestClient.builder(new HttpHost("localhost", 9200, "http")));
+
+        // Elasticsearch の String 型のデータを更新
+        UpdateRequest updateRequest = new UpdateRequest("employeeindex", "002");
+        updateRequest.doc("department", "Bussiness");
+        // 更新されたか id の確認
+        UpdateResponse updateResponse = client.update(updateRequest, RequestOptions.DEFAULT);
+        System.out.println("updated response id: " + updateResponse.getId());
+    }
+}

--- a/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
@@ -1,8 +1,9 @@
 package elasticsearch.sample;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.index.IndexRequest;
@@ -10,6 +11,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.xcontent.XContentType;
 
 public class JavaElasticUpdateDelete {
 
@@ -39,26 +41,36 @@ public class JavaElasticUpdateDelete {
         // RequestOptions.DEFAULT);
         // System.out.println("updated response id: " + updateResponse.getId());
 
-        // update way2 Elasticsearch の String 型でデータ更新（元からデータがあるidの場合は一新される）
+        // // update way2 Elasticsearch の String 型でデータ更新（元からデータがあるidの場合は一新される）
+        // IndexRequest request = new IndexRequest("employeeindex");
+        // request.id("001");
+        // request.source("company", "SpaceX");
+        // IndexResponse indexResponse = client.index(request, RequestOptions.DEFAULT);
+        // System.out.println("response id: " + indexResponse.getId());
+        // System.out.println(indexResponse.getResult().name());
+
+        // // update way2
+        // // Elasticsearch を Map 型でデータ更新（元からデータがあるidの場合は一新される）
+        // Map<String, Object> updateMap = new HashMap<String, Object>();
+        // updateMap.put("firstname", "Sundar");
+        // updateMap.put("lastname", "Pichai");
+        // updateMap.put("company", "Google");
+        // updateMap.put("sector", "IT");
+        // IndexRequest request2 = new IndexRequest("employeeindex");
+        // request2.id("002");
+        // request2.source(updateMap);
+        // IndexResponse indexResponseUpdate = client.index(request2,
+        // RequestOptions.DEFAULT);
+        // System.out.println("response id: " + indexResponseUpdate.getId());
+        // System.out.println(indexResponse.getResult().name());
+
+        EmployeePojo emp = new EmployeePojo("Elon01", "Musk01", LocalDate.now());
+        // POJO を JSON 形式にして Elasticsearch のデータを更新
         IndexRequest request = new IndexRequest("employeeindex");
         request.id("001");
-        request.source("company", "SpaceX");
+        request.source(new ObjectMapper().writeValueAsString(emp), XContentType.JSON);
         IndexResponse indexResponse = client.index(request, RequestOptions.DEFAULT);
-        System.out.println("response id: " + indexResponse.getId());
-        System.out.println(indexResponse.getResult().name());
-
-        // update way2
-        // Elasticsearch を Map 型でデータ更新（元からデータがあるidの場合は一新される）
-        Map<String, Object> updateMap = new HashMap<String, Object>();
-        updateMap.put("firstname", "Sundar");
-        updateMap.put("lastname", "Pichai");
-        updateMap.put("company", "Google");
-        updateMap.put("sector", "IT");
-        IndexRequest request2 = new IndexRequest("employeeindex");
-        request2.id("002");
-        request2.source(updateMap);
-        IndexResponse indexResponseUpdate = client.index(request2, RequestOptions.DEFAULT);
-        System.out.println("response id: " + indexResponseUpdate.getId());
+        System.out.println("response id:" + indexResponse.getId());
         System.out.println(indexResponse.getResult().name());
     }
 }

--- a/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
@@ -1,6 +1,8 @@
 package elasticsearch.sample;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -16,11 +18,23 @@ public class JavaElasticUpdateDelete {
         RestHighLevelClient client = new RestHighLevelClient(
                 RestClient.builder(new HttpHost("localhost", 9200, "http")));
 
-        // Elasticsearch の String 型のデータを更新
-        UpdateRequest updateRequest = new UpdateRequest("employeeindex", "002");
-        updateRequest.doc("department", "Bussiness");
-        // 更新されたか id の確認
-        UpdateResponse updateResponse = client.update(updateRequest, RequestOptions.DEFAULT);
+        // // Elasticsearch の String 型でデータ更新
+        // UpdateRequest updateRequest = new UpdateRequest("employeeindex", "002");
+        // updateRequest.doc("department", "Bussiness");
+        // // 更新されたか id の確認
+        // UpdateResponse updateResponse = client.update(updateRequest,
+        // RequestOptions.DEFAULT);
+        // System.out.println("updated response id: " + updateResponse.getId());
+
+        // Map を作成
+        Map<String, Object> updateMap = new HashMap<String, Object>();
+        updateMap.put("firstname", "Sundar");
+        updateMap.put("lastname", "Pichai");
+        updateMap.put("company", "Google");
+        updateMap.put("sector", "IT");
+        // Elasticsearch を Map 型でデータ更新, 追加
+        UpdateRequest request = new UpdateRequest("employeeindex", "002").doc(updateMap);
+        UpdateResponse updateResponse = client.update(request, RequestOptions.DEFAULT);
         System.out.println("updated response id: " + updateResponse.getId());
     }
 }

--- a/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.http.HttpHost;
-import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -18,7 +18,7 @@ public class JavaElasticUpdateDelete {
         RestHighLevelClient client = new RestHighLevelClient(
                 RestClient.builder(new HttpHost("localhost", 9200, "http")));
 
-        // // Elasticsearch の String 型でデータ更新
+        // // Elasticsearch の String 型でデータ更新, 追加
         // UpdateRequest updateRequest = new UpdateRequest("employeeindex", "002");
         // updateRequest.doc("department", "Bussiness");
         // // 更新されたか id の確認
@@ -26,15 +26,39 @@ public class JavaElasticUpdateDelete {
         // RequestOptions.DEFAULT);
         // System.out.println("updated response id: " + updateResponse.getId());
 
-        // Map を作成
+        // // Map を作成
+        // Map<String, Object> updateMap = new HashMap<String, Object>();
+        // updateMap.put("firstname", "Sundar");
+        // updateMap.put("lastname", "Pichai");
+        // updateMap.put("company", "Google");
+        // updateMap.put("sector", "IT");
+        // // Elasticsearch を Map 型でデータ更新, 追加
+        // UpdateRequest request = new UpdateRequest("employeeindex",
+        // "002").doc(updateMap);
+        // UpdateResponse updateResponse = client.update(request,
+        // RequestOptions.DEFAULT);
+        // System.out.println("updated response id: " + updateResponse.getId());
+
+        // update way2 Elasticsearch の String 型でデータ更新（元からデータがあるidの場合は一新される）
+        IndexRequest request = new IndexRequest("employeeindex");
+        request.id("001");
+        request.source("company", "SpaceX");
+        IndexResponse indexResponse = client.index(request, RequestOptions.DEFAULT);
+        System.out.println("response id: " + indexResponse.getId());
+        System.out.println(indexResponse.getResult().name());
+
+        // update way2
+        // Elasticsearch を Map 型でデータ更新（元からデータがあるidの場合は一新される）
         Map<String, Object> updateMap = new HashMap<String, Object>();
         updateMap.put("firstname", "Sundar");
         updateMap.put("lastname", "Pichai");
         updateMap.put("company", "Google");
         updateMap.put("sector", "IT");
-        // Elasticsearch を Map 型でデータ更新, 追加
-        UpdateRequest request = new UpdateRequest("employeeindex", "002").doc(updateMap);
-        UpdateResponse updateResponse = client.update(request, RequestOptions.DEFAULT);
-        System.out.println("updated response id: " + updateResponse.getId());
+        IndexRequest request2 = new IndexRequest("employeeindex");
+        request2.id("002");
+        request2.source(updateMap);
+        IndexResponse indexResponseUpdate = client.index(request2, RequestOptions.DEFAULT);
+        System.out.println("response id: " + indexResponseUpdate.getId());
+        System.out.println(indexResponse.getResult().name());
     }
 }

--- a/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticUpdateDelete.java
@@ -24,9 +24,9 @@ public class JavaElasticUpdateDelete {
         // // Elasticsearch の String 型でデータ更新, 追加
         // UpdateRequest updateRequest = new UpdateRequest("employeeindex", "002");
         // updateRequest.doc("department", "Bussiness");
-        // // 更新されたか id の確認
         // UpdateResponse updateResponse = client.update(updateRequest,
         // RequestOptions.DEFAULT);
+        // // 更新されたか id の確認
         // System.out.println("updated response id: " + updateResponse.getId());
 
         // // Map を作成
@@ -40,6 +40,7 @@ public class JavaElasticUpdateDelete {
         // "002").doc(updateMap);
         // UpdateResponse updateResponse = client.update(request,
         // RequestOptions.DEFAULT);
+        // // 更新されたか id の確認
         // System.out.println("updated response id: " + updateResponse.getId());
 
         // // update way2 Elasticsearch の String 型でデータ更新（元からデータがあるidの場合は一新される）
@@ -47,6 +48,7 @@ public class JavaElasticUpdateDelete {
         // request.id("001");
         // request.source("company", "SpaceX");
         // IndexResponse indexResponse = client.index(request, RequestOptions.DEFAULT);
+        // // 更新されたか id の確認
         // System.out.println("response id: " + indexResponse.getId());
         // System.out.println(indexResponse.getResult().name());
 
@@ -62,6 +64,7 @@ public class JavaElasticUpdateDelete {
         // request2.source(updateMap);
         // IndexResponse indexResponseUpdate = client.index(request2,
         // RequestOptions.DEFAULT);
+        // // 更新されたか id の確認
         // System.out.println("response id: " + indexResponseUpdate.getId());
         // System.out.println(indexResponse.getResult().name());
 
@@ -72,6 +75,7 @@ public class JavaElasticUpdateDelete {
         // request.source(new ObjectMapper().writeValueAsString(emp),
         // XContentType.JSON);
         // IndexResponse indexResponse = client.index(request, RequestOptions.DEFAULT);
+        // // 更新されたか id の確認
         // System.out.println("response id:" + indexResponse.getId());
         // System.out.println(indexResponse.getResult().name());
 
@@ -88,6 +92,7 @@ public class JavaElasticUpdateDelete {
         try {
             BulkByScrollResponse bulkResponse = client.updateByQuery(updateByQueryRequest, RequestOptions.DEFAULT);
             long totalDocs = bulkResponse.getTotal();
+            // 更新されたか id の確認
             System.out.println("updated response id: " + totalDocs);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
### Update data into Elasticsearch from Java Client

- Updating a Sample String Value into Elasticsearch
- Updating Id with particular Map values into Elasticsearch
- update way2 データ更新（元からデータがあるidの場合は一新される）
- POJO を JSON 形式にして Elasticsearch のデータを更新
- Using API- UpdateByQueryRequest
- コメントアウトを修正
  - 正常に処理が行われたかを確認する位置を修正した
  - 修正前は 作成, 更新 のためのコードも含まれていた