### PR TITLE
Feature/202109/elasticsearch delete data

### DIFF
--- a/src/main/java/elasticsearch/sample/JavaElasticDelete.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticDelete.java
@@ -1,0 +1,16 @@
+package elasticsearch.sample;
+
+import java.io.IOException;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+
+public class JavaElasticDelete {
+
+    public static void main(String[] args) throws IOException {
+        // Elasticsearch に接続
+        RestHighLevelClient client = new RestHighLevelClient(
+                RestClient.builder(new HttpHost("localhost", 9200, "http")));
+    }
+}

--- a/src/main/java/elasticsearch/sample/JavaElasticDelete.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticDelete.java
@@ -3,8 +3,7 @@ package elasticsearch.sample;
 import java.io.IOException;
 
 import org.apache.http.HttpHost;
-import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -16,10 +15,17 @@ public class JavaElasticDelete {
         RestHighLevelClient client = new RestHighLevelClient(
                 RestClient.builder(new HttpHost("localhost", 9200, "http")));
 
-        // 特定の index id のデータを削除
-        DeleteRequest deleteRequest = new DeleteRequest("employeeindex", "002");
-        DeleteResponse deleteResponse = client.delete(deleteRequest, RequestOptions.DEFAULT);
-        // 削除した id を確認
-        System.out.println("response id: " + deleteResponse.getId());
+        // // 特定の index id のデータを削除
+        // DeleteRequest deleteRequest = new DeleteRequest("employeeindex", "002");
+        // DeleteResponse deleteResponse = client.delete(deleteRequest,
+        // RequestOptions.DEFAULT);
+        // // 削除した id を確認
+        // System.out.println("response id: " + deleteResponse.getId());
+
+        // Delete the index
+        // 特定の index ごと削除
+        DeleteIndexRequest request = new DeleteIndexRequest("employeeindex");
+        client.indices().delete(request, RequestOptions.DEFAULT);
+        System.out.println("Delete Done ");
     }
 }

--- a/src/main/java/elasticsearch/sample/JavaElasticDelete.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticDelete.java
@@ -3,6 +3,9 @@ package elasticsearch.sample;
 import java.io.IOException;
 
 import org.apache.http.HttpHost;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 
@@ -12,5 +15,11 @@ public class JavaElasticDelete {
         // Elasticsearch に接続
         RestHighLevelClient client = new RestHighLevelClient(
                 RestClient.builder(new HttpHost("localhost", 9200, "http")));
+
+        // 特定の index id のデータを削除
+        DeleteRequest deleteRequest = new DeleteRequest("employeeindex", "002");
+        DeleteResponse deleteResponse = client.delete(deleteRequest, RequestOptions.DEFAULT);
+        // 削除した id を確認
+        System.out.println("response id: " + deleteResponse.getId());
     }
 }

--- a/src/main/java/elasticsearch/sample/JavaElasticUpdate.java
+++ b/src/main/java/elasticsearch/sample/JavaElasticUpdate.java
@@ -14,7 +14,7 @@ import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 
-public class JavaElasticUpdateDelete {
+public class JavaElasticUpdate {
 
     public static void main(String[] args) throws IOException {
         // Elasticsearch に接続


### PR DESCRIPTION
### Delete data into Elasticsearch from Java Client

- JavaElasticUpdateDelete => JavaElasticUpdate へリファクタリング
- JavaElasticDelete ファイルを作成
  - Delete data into Elasticsearch from Java Client のサンプルを作成するため
- Elasticsearch の特定の index id のデータを削除
- Elasticsearch の特定の index ごと削除