### PR TITLE
Feature/202109/elasticsearch client close

### DIFF
--- a/src/main/java/elasticsearch/sample/create/CreateIndex.java
+++ b/src/main/java/elasticsearch/sample/create/CreateIndex.java
@@ -27,5 +27,8 @@ public class CreateIndex {
                 RequestOptions.DEFAULT);
         // index が作成されたか確認
         System.out.println("response id: " + createIndexResponse.index());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/create/InsertMapData.java
+++ b/src/main/java/elasticsearch/sample/create/InsertMapData.java
@@ -33,5 +33,8 @@ public class InsertMapData {
         // 正常に処理されたか確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/create/InsertPOJOMappingsData.java
+++ b/src/main/java/elasticsearch/sample/create/InsertPOJOMappingsData.java
@@ -35,5 +35,8 @@ public class InsertPOJOMappingsData {
         // 正常に処理されたか確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/create/InsertStringData.java
+++ b/src/main/java/elasticsearch/sample/create/InsertStringData.java
@@ -26,5 +26,8 @@ public class InsertStringData {
         // 正常に処理されたか確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/create/JavaElasticClient.java
+++ b/src/main/java/elasticsearch/sample/create/JavaElasticClient.java
@@ -70,5 +70,8 @@ public class JavaElasticClient {
         // 正常に処理されたか確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println("response name: " + indexResponse.getResult().name());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/delete/DeleteIndex.java
+++ b/src/main/java/elasticsearch/sample/delete/DeleteIndex.java
@@ -22,5 +22,8 @@ public class DeleteIndex {
         client.indices().delete(request, RequestOptions.DEFAULT);
 
         System.out.println("Delete Done ");
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/delete/DeleteIndexId.java
+++ b/src/main/java/elasticsearch/sample/delete/DeleteIndexId.java
@@ -23,5 +23,8 @@ public class DeleteIndexId {
                 RequestOptions.DEFAULT);
         // 削除した id を確認
         System.out.println("response id: " + deleteResponse.getId());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/delete/JavaElasticDelete.java
+++ b/src/main/java/elasticsearch/sample/delete/JavaElasticDelete.java
@@ -27,5 +27,8 @@ public class JavaElasticDelete {
         DeleteIndexRequest request = new DeleteIndexRequest("employeeindex");
         client.indices().delete(request, RequestOptions.DEFAULT);
         System.out.println("Delete Done ");
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/update/JavaElasticUpdate.java
+++ b/src/main/java/elasticsearch/sample/update/JavaElasticUpdate.java
@@ -98,6 +98,9 @@ public class JavaElasticUpdate {
             long totalDocs = bulkResponse.getTotal();
             // 更新されたか id の確認
             System.out.println("updated response id: " + totalDocs);
+
+            // クライアントを閉じる
+            client.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/elasticsearch/sample/update/UpdateMapData.java
+++ b/src/main/java/elasticsearch/sample/update/UpdateMapData.java
@@ -32,5 +32,8 @@ public class UpdateMapData {
                 RequestOptions.DEFAULT);
         // 更新されたか id の確認
         System.out.println("updated response id: " + updateResponse.getId());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/update/UpdateMapDataRenewal.java
+++ b/src/main/java/elasticsearch/sample/update/UpdateMapDataRenewal.java
@@ -36,5 +36,8 @@ public class UpdateMapDataRenewal {
         // 更新されたか id の確認
         System.out.println("response id: " + indexResponseUpdate.getId());
         System.out.println(indexResponseUpdate.getResult().name());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/update/UpdatePOJOMappingsData.java
+++ b/src/main/java/elasticsearch/sample/update/UpdatePOJOMappingsData.java
@@ -36,5 +36,8 @@ public class UpdatePOJOMappingsData {
         // 更新されたか id の確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println(indexResponse.getResult().name());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/update/UpdateQueryRequest.java
+++ b/src/main/java/elasticsearch/sample/update/UpdateQueryRequest.java
@@ -39,6 +39,9 @@ public class UpdateQueryRequest {
             long totalDocs = bulkResponse.getTotal();
             // 更新されたか id の確認
             System.out.println("updated response id: " + totalDocs);
+
+            // クライアントを閉じる
+            client.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/elasticsearch/sample/update/UpdateStringData.java
+++ b/src/main/java/elasticsearch/sample/update/UpdateStringData.java
@@ -24,5 +24,8 @@ public class UpdateStringData {
                 RequestOptions.DEFAULT);
         // 更新されたか id の確認
         System.out.println("updated response id: " + updateResponse.getId());
+
+        // クライアントを閉じる
+        client.close();
     }
 }

--- a/src/main/java/elasticsearch/sample/update/UpdateStringDataRenewal.java
+++ b/src/main/java/elasticsearch/sample/update/UpdateStringDataRenewal.java
@@ -25,5 +25,8 @@ public class UpdateStringDataRenewal {
         // 更新されたか id の確認
         System.out.println("response id: " + indexResponse.getId());
         System.out.println(indexResponse.getResult().name());
+
+        // クライアントを閉じる
+        client.close();
     }
 }


### PR DESCRIPTION
### CRUD 後にクライアントを閉じるコードを追記

いちいちターミナル上で処理(Elasticsearchとの接続解除)を終了する必要がなくなる