### PR TITLE
Feature/202109/elasticsearch read

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ $ curl http://localhost:9200/
 ```
 $ kibana
 ```
+
+## Document
+
+### Create
+
+### Read
+
+- [Search API](https://www.elastic.co/guide//en/elasticsearch/client/java-rest/master/java-rest-high-search.html)
+
+### Update
+
+### Delete

--- a/pom.xml
+++ b/pom.xml
@@ -48,5 +48,11 @@
       <artifactId>jackson-databind</artifactId>
       <version>2.11.1</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.8</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/elasticsearch/sample/read/ReadIndexData.java
+++ b/src/main/java/elasticsearch/sample/read/ReadIndexData.java
@@ -1,6 +1,13 @@
 package elasticsearch.sample.read;
 
 import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
 
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.search.SearchRequest;
@@ -24,9 +31,18 @@ public class ReadIndexData {
         searchSourceBuilder.query(QueryBuilders.matchAllQuery());
         searchRequest.source(searchSourceBuilder);
 
-        // sampleindex のデータを取得_結果を取得・表示
+        // sampleindex のデータを取得_結果を取得
         SearchResponse searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
-        System.out.println("searchResponse: " + searchResponse);
+
+        // JSON を整形
+        String searchResponseString = searchResponse.toString();
+        Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+        JsonReader reader = new JsonReader(new StringReader(searchResponseString));
+        Map<String, Object> map = gson.fromJson(reader, new TypeToken<Map<String, Object>>() {
+        }.getType());
+
+        // sampleindex のデータを取得_結果を表示
+        System.out.println("searchResponse: \n" + gson.toJson(map));
 
         // クライアントを閉じる
         client.close();

--- a/src/main/java/elasticsearch/sample/read/ReadIndexData.java
+++ b/src/main/java/elasticsearch/sample/read/ReadIndexData.java
@@ -18,13 +18,14 @@ public class ReadIndexData {
         RestHighLevelClient client = new RestHighLevelClient(
                 RestClient.builder(new HttpHost("localhost", 9200, "http")));
 
+        // sampleindex のデータを取得_Query
         SearchRequest searchRequest = new SearchRequest("sampleindex");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(QueryBuilders.matchAllQuery());
         searchRequest.source(searchSourceBuilder);
 
+        // sampleindex のデータを取得_結果を取得・表示
         SearchResponse searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
-
         System.out.println("searchResponse: " + searchResponse);
 
         // クライアントを閉じる

--- a/src/main/java/elasticsearch/sample/read/ReadIndexData.java
+++ b/src/main/java/elasticsearch/sample/read/ReadIndexData.java
@@ -1,0 +1,33 @@
+package elasticsearch.sample.read;
+
+import java.io.IOException;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+public class ReadIndexData {
+
+    public static void main(String[] args) throws IOException {
+        // Elasticsearch に接続
+        RestHighLevelClient client = new RestHighLevelClient(
+                RestClient.builder(new HttpHost("localhost", 9200, "http")));
+
+        SearchRequest searchRequest = new SearchRequest();
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+        searchRequest.source(searchSourceBuilder);
+
+        SearchResponse searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
+
+        System.out.println("searchResponse: " + searchResponse);
+
+        // クライアントを閉じる
+        client.close();
+    }
+}

--- a/src/main/java/elasticsearch/sample/read/ReadIndexData.java
+++ b/src/main/java/elasticsearch/sample/read/ReadIndexData.java
@@ -18,7 +18,7 @@ public class ReadIndexData {
         RestHighLevelClient client = new RestHighLevelClient(
                 RestClient.builder(new HttpHost("localhost", 9200, "http")));
 
-        SearchRequest searchRequest = new SearchRequest();
+        SearchRequest searchRequest = new SearchRequest("sampleindex");
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(QueryBuilders.matchAllQuery());
         searchRequest.source(searchSourceBuilder);


### PR DESCRIPTION
### Elasticsearch のデータを読み込むコードを作成
```
GET _search
{
  "query": {
    "match_all": {}
  }
}
```

- sampleindex のデータを取得
```
GET sampleindex/_search
{
  "query": {
    "match_all": {}
  }
}
```

- Gson をpomに追記
- JSON を整形して出力
- README に Document を追記